### PR TITLE
Nocd5 feature spike

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CFLAGS = -nologo -MT -O2 -W3 -EHsc -DNDEBUG
 LDFLAGS = -nologo
 
 UINC = 
-ULIB = user32.lib gdi32.lib shell32.lib
+ULIB = user32.lib gdi32.lib shell32.lib shlwapi.lib
 
 .SUFFIXES: .exe .obj .cpp .rc .res
 

--- a/main.cpp
+++ b/main.cpp
@@ -559,7 +559,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 		KillTimer(hWnd, 0x3571);
 		PostQuitMessage(0);
 		if(WaitForSingleObject(gChild, 0) == WAIT_TIMEOUT)
-			TerminateProcess(gChild, 0);
+			PostMessage(gConWnd, WM_CLOSE, 0, 0);
 		break;
 	case WM_TIMER:
 		onTimer(hWnd);


### PR DESCRIPTION
nyaosの
3.3.0_2 (2012/01/30)
    ウインドウを閉じた場合もヒストリ保存や Lua関数 nyaos.goodbye.\* を呼び出せるようになった。 
ここら辺の対応パッチです(http://nyaos.org/d/index.cgi?p=%282012.01.30%29)

初gitなもので色々作法がよろしくないところがあるかもしれませんが、
修正内容に問題なければパッチ取り込みよろしくお願いします。
