### PR TITLE
add icon option

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -684,12 +684,14 @@ static BOOL create_window(ckOpt& opt)
 	HINSTANCE hInstance = GetModuleHandle(NULL);
 	LPWSTR	className = L"CkwWindowClass";
 	const char*	conf_title;
+	const char*	conf_icon;
 	LPWSTR	title;
 	WNDCLASSEX wc;
 	DWORD	style = WS_OVERLAPPEDWINDOW;
 	DWORD	exstyle = WS_EX_ACCEPTFILES;
 	LONG	width, height;
 	LONG	posx, posy;
+	HICON	icon;
 
 	if(opt.isTranspColor() ||
 	   (0 < opt.getTransp() && opt.getTransp() < 255))
@@ -719,6 +721,17 @@ static BOOL create_window(ckOpt& opt)
           ZeroMemory(title, sizeof(wchar_t) * (strlen(conf_title)+1));
           MultiByteToWideChar(CP_ACP, 0, conf_title, (int)strlen(conf_title), title, (int)(sizeof(wchar_t) * (strlen(conf_title)+1)) );
         }
+
+	conf_icon = opt.getIcon();
+	if(!conf_icon || !conf_icon[0]){
+		icon = LoadIcon(hInstance, (LPCTSTR)IDR_ICON);
+	}else{
+		LPWSTR icon_path = new wchar_t[ strlen(conf_icon)+1 ];
+		ZeroMemory(icon_path, sizeof(wchar_t) * (strlen(conf_icon)+1));
+		MultiByteToWideChar(CP_ACP, 0, conf_icon, (int)strlen(conf_icon), icon_path, (int)(sizeof(wchar_t) * (strlen(conf_icon)+1)) );
+		icon = (HICON)LoadImage(NULL, icon_path, IMAGE_ICON, 0, 0, LR_LOADFROMFILE);
+		delete [] icon_path;
+	}
 
 	/* calc window size */
 	CONSOLE_SCREEN_BUFFER_INFO csi;
@@ -764,7 +777,7 @@ static BOOL create_window(ckOpt& opt)
 	wc.cbClsExtra = 0;
 	wc.cbWndExtra = 0;
 	wc.hInstance = hInstance;
-	wc.hIcon = LoadIcon(hInstance, (LPCTSTR)IDR_ICON);
+	wc.hIcon = icon;
 	wc.hCursor = LoadCursor(NULL, IDC_ARROW);
 	wc.hbrBackground = CreateSolidBrush(gColorTable[0]);
 	wc.lpszMenuName = NULL;

--- a/option.cpp
+++ b/option.cpp
@@ -1016,6 +1016,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 	CHK_MISC("cursorColor",		"cr",		lookupColor(value, m_colorCursor));
 	CHK_MISC("cursorImeColor",	"cri",		lookupColor(value, m_colorCursorIme));
 	CHK_MISC("backgroundBitmap",	"bitmap",	m_bgBmp = value);
+	CHK_MISC("icon",		"ico",		m_icon = value);
 	CHK_MISC("geometry",		"g",		geometry(value));
 	CHK_BOOL(NULL, 			"iconic",	m_isIconic);
 	CHK_MISC("font",		"fn",		m_font = value);
@@ -1067,6 +1068,7 @@ static void usage(bool isLong)
 	"color14",		NULL,		"color",	"",
 	"color15",		NULL,		"color",	"",
 	"backgroundBitmap",	"bitmap",	"string",	"background bmp file",
+	"icon",			"ico",		"string",	"icon file",
 	"geometry",		"g",		"string",	"window layout. ( ex. 80x24+0+0 )",
 	NULL, 			"iconic",	"boolean",	"start iconic",
 	"font",			"fn",		"string",	"text font name",

--- a/option.h
+++ b/option.h
@@ -60,6 +60,10 @@ public:
 	{
 		return((m_title.size()) ? m_title.c_str() : NULL);
 	}
+	const char*	getIcon()
+	{
+		return((m_icon.size()) ? m_icon.c_str() : NULL);
+	}
 
 
 protected:
@@ -84,6 +88,7 @@ private:
 	COLORREF	m_colorCursorIme;
 	COLORREF	m_colors[17];
 	std::string	m_bgBmp;
+	std::string	m_icon;
 	bool		m_scrollHide;
 	bool		m_scrollRight;
 	int		m_saveLines;


### PR DESCRIPTION
タスクバーなどでの識別が容易になるように、アイコンを指定するオプションを追加しました。
cmd.exe でも cygwin や GitBash ではアイコンが変わりますので
ckw でも変わると便利だと思うのですがいかがでしょう。

仮に short option を `-ico` に long opthon を `--icon` にしています。
short がぜんぜん short じゃありませんが、ちょうどいいのを思いつきませんでした。
