### PR TITLE
remove short option for icon setting

### DIFF
--- a/option.cpp
+++ b/option.cpp
@@ -1016,7 +1016,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 	CHK_MISC("cursorColor",		"cr",		lookupColor(value, m_colorCursor));
 	CHK_MISC("cursorImeColor",	"cri",		lookupColor(value, m_colorCursorIme));
 	CHK_MISC("backgroundBitmap",	"bitmap",	m_bgBmp = value);
-	CHK_MISC("icon",		"ico",		m_icon = value);
+	CHK_MISC("icon",		NULL,		m_icon = value);
 	CHK_MISC("geometry",		"g",		geometry(value));
 	CHK_BOOL(NULL, 			"iconic",	m_isIconic);
 	CHK_MISC("font",		"fn",		m_font = value);
@@ -1068,7 +1068,7 @@ static void usage(bool isLong)
 	"color14",		NULL,		"color",	"",
 	"color15",		NULL,		"color",	"",
 	"backgroundBitmap",	"bitmap",	"string",	"background bmp file",
-	"icon",			"ico",		"string",	"icon file",
+	"icon",			NULL,		"string",	"icon file",
 	"geometry",		"g",		"string",	"window layout. ( ex. 80x24+0+0 )",
 	NULL, 			"iconic",	"boolean",	"start iconic",
 	"font",			"fn",		"string",	"text font name",


### PR DESCRIPTION
#3 の採用ありがとうごさいます。

コードをよくよく読んでみると short option 無しでも OK のようですので、
short option の `-ico` は消してしまいたいです。

よろしくお願いします。
