### PR TITLE
Fix load icon

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -692,6 +692,7 @@ static BOOL create_window(ckOpt& opt)
 	LONG	width, height;
 	LONG	posx, posy;
 	HICON	icon;
+	HICON	iconsm;
 
 	if(opt.isTranspColor() ||
 	   (0 < opt.getTransp() && opt.getTransp() < 255))
@@ -729,7 +730,8 @@ static BOOL create_window(ckOpt& opt)
 		LPWSTR icon_path = new wchar_t[ strlen(conf_icon)+1 ];
 		ZeroMemory(icon_path, sizeof(wchar_t) * (strlen(conf_icon)+1));
 		MultiByteToWideChar(CP_ACP, 0, conf_icon, (int)strlen(conf_icon), icon_path, (int)(sizeof(wchar_t) * (strlen(conf_icon)+1)) );
-		icon = (HICON)LoadImage(NULL, icon_path, IMAGE_ICON, 0, 0, LR_LOADFROMFILE);
+		icon   = (HICON)LoadImage(NULL, icon_path, IMAGE_ICON, GetSystemMetrics(SM_CXICON),   GetSystemMetrics(SM_CYICON),   LR_LOADFROMFILE);
+		iconsm = (HICON)LoadImage(NULL, icon_path, IMAGE_ICON, GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON), LR_LOADFROMFILE);
 		delete [] icon_path;
 	}
 
@@ -782,7 +784,7 @@ static BOOL create_window(ckOpt& opt)
 	wc.hbrBackground = CreateSolidBrush(gColorTable[0]);
 	wc.lpszMenuName = NULL;
 	wc.lpszClassName = className;
-	wc.hIconSm = NULL;
+	wc.hIconSm = iconsm;
 	if(! RegisterClassEx(&wc))
 		return(FALSE);
 

--- a/main.cpp
+++ b/main.cpp
@@ -725,7 +725,8 @@ static BOOL create_window(ckOpt& opt)
 
 	conf_icon = opt.getIcon();
 	if(!conf_icon || !conf_icon[0]){
-		icon = LoadIcon(hInstance, (LPCTSTR)IDR_ICON);
+		icon   = (HICON)LoadImage(hInstance, MAKEINTRESOURCE(IDR_ICON), IMAGE_ICON, GetSystemMetrics(SM_CXICON),   GetSystemMetrics(SM_CYICON),   LR_DEFAULTCOLOR);
+		iconsm = (HICON)LoadImage(hInstance, MAKEINTRESOURCE(IDR_ICON), IMAGE_ICON, GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON), LR_DEFAULTCOLOR);
 	}else{
 		LPWSTR icon_path = new wchar_t[ strlen(conf_icon)+1 ];
 		ZeroMemory(icon_path, sizeof(wchar_t) * (strlen(conf_icon)+1));


### PR DESCRIPTION
ロードするアイコンのサイズを明示し、小さなアイコンを指定するようにしました。

southly/ckw-mod#1

> WNDCLASSEX.hIconSmも指定した方がタイトルバーやツールバーには
> 小さいアイコンが表示されるので良いと思い、追加してみました。
> また、アイコンサイズを指定せずLoadImageすると普通サイズではなく
> 小さいアイコンを返すアイコンがあったため、
> 明示的にアイコンサイズを指定するよう修正してみました。
