### PR TITLE
fix the size of ckOpt::m_colors

### DIFF
--- a/option.h
+++ b/option.h
@@ -86,7 +86,7 @@ private:
 	COLORREF	m_colorBg;
 	COLORREF	m_colorCursor;
 	COLORREF	m_colorCursorIme;
-	COLORREF	m_colors[17];
+	COLORREF	m_colors[16];
 	std::string	m_bgBmp;
 	std::string	m_icon;
 	bool		m_scrollHide;


### PR DESCRIPTION
パレット色は`color0～15`の16色なので ckOpt::m_colors のサイズは16で十分のはずです。
現状でも困りませんがご報告ということで。

この数は定数にしておいた方が良いかもしれませんね。
