### PR TITLE
GCC でビルドできるようにする

### DIFF
--- a/ckw.h
+++ b/ckw.h
@@ -7,6 +7,11 @@
 #include <windows.h>
 #include <wchar.h>
 
+#ifndef _MSC_VER // for gcc
+#include <ddk/ntapi.h>
+#define STARTF_TITLEISLINKNAME 0x00000800
+#endif
+
 #ifdef _MSC_VER
 #define strcasecmp _stricmp
 #endif

--- a/ime_wrap.cpp
+++ b/ime_wrap.cpp
@@ -39,7 +39,9 @@ HIMC WINAPI ImmGetContext(HWND hwnd)
 {
 	if(fn_GetContext)
 		return( fn_GetContext(hwnd) );
-	return(NULL);
+
+	HIMC imc = {0};
+	return(imc);
 }
 
 BOOL WINAPI ImmReleaseContext(HWND hwnd, HIMC imc)

--- a/ime_wrap.cpp
+++ b/ime_wrap.cpp
@@ -18,6 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *---------------------------------------------------------------------------*/
+#define _CRT_SECURE_NO_WARNINGS 1
 #include <windows.h>
 #include <imm.h>
 

--- a/main.cpp
+++ b/main.cpp
@@ -533,8 +533,8 @@ void	onTimer(HWND hWnd)
 		__set_ime_position(hWnd);
 	}
 
-	int w = CSI_WndCols(gCSI);
-	int h = CSI_WndRows(gCSI);
+	DWORD w = CSI_WndCols(gCSI);
+	DWORD h = CSI_WndRows(gCSI);
 	if(gWinW != w || gWinH != h) {
 		w = (w * gFontW) + (gBorderSize * 2) + (gFrame.right - gFrame.left);
 		h = (h * gFontH) + (gBorderSize * 2) + (gFrame.bottom - gFrame.top);
@@ -682,7 +682,7 @@ static BOOL create_window(ckOpt& opt)
 	trace("create_window\n");
 
 	HINSTANCE hInstance = GetModuleHandle(NULL);
-	LPWSTR	className = L"CkwWindowClass";
+	LPCWSTR	className = L"CkwWindowClass";
 	const char*	conf_icon;
 	WNDCLASSEX wc;
 	DWORD	style = WS_OVERLAPPEDWINDOW;

--- a/main.cpp
+++ b/main.cpp
@@ -1186,7 +1186,7 @@ static void _terminate()
 #endif
 
 /*----------*/
-int APIENTRY wWinMain(HINSTANCE hInst, HINSTANCE hPrev, LPWSTR lpCmdLine, int nCmdShow)
+int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmdLine, int nCmdShow)
 {
 #ifdef _DEBUG
 	char *a = new char[1];

--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *---------------------------------------------------------------------------*/
+#define _CRT_SECURE_NO_WARNINGS 1
 #include "ckw.h"
 #include "ime_wrap.h"
 #include "rsrc.h"

--- a/makefile-gcc
+++ b/makefile-gcc
@@ -7,13 +7,13 @@ OBJ     = main.o \
           ime_wrap.o \
           misc.o
 
-DEFINES = -DNDEBUG -Dwcscat_s=wcscat
+DEFINES = -DNDEBUG
 # --------------------------------------------------------------------
 
 ifdef INSTDIR
-all: $(INSTDIR)\$(BIN)
+all: ver $(INSTDIR)\$(BIN)
 else
-all: $(BIN)
+all: ver $(BIN)
 endif
 
 $(INSTDIR)\$(BIN): $(BIN)
@@ -25,18 +25,20 @@ clean:
 CC      = gcc.exe
 CP      = g++.exe
 WINDRES = windres.exe -J rc -O coff --include-dir $(<D)
-CFLAGS  = -Os -Wall \
+CFLAGS  = -Os -Wall -Wextra \
           -fno-rtti \
           -fno-exceptions \
           -fomit-frame-pointer \
-          -fmove-all-movables \
           -c $(DEFINES)
 LFLAGS  =
-LOPTS   = -Wl,--entry,_wWinMain,--enable-stdcall-fixup
-LIBS    = -s -mwindows -nostartfiles
+LOPTS   = -Wl,--enable-stdcall-fixup
+LIBS    = -s -mwindows -lshlwapi -static-libgcc -static-libstdc++
 
 
 # --------------------------------------------------------------------
+
+ver:
+	cmd /c version.bat > version.h
 
 $(BIN): $(OBJ) $(RES) makefile-gcc
 	$(CP) $(LFLAGS) $(OBJ) $(RES) $(LIBS) $(LOPTS) -o $(BIN)

--- a/makefile-gcc
+++ b/makefile-gcc
@@ -26,6 +26,7 @@ CC      = gcc.exe
 CP      = g++.exe
 WINDRES = windres.exe -J rc -O coff --include-dir $(<D)
 CFLAGS  = -Os -Wall -Wextra \
+          -Wno-unused-parameter \
           -fno-rtti \
           -fno-exceptions \
           -fomit-frame-pointer \

--- a/misc.cpp
+++ b/misc.cpp
@@ -264,7 +264,7 @@ L" 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA."
 
 /*----------*/
 void	sysmenu_init_topmost(HWND hWnd, HMENU hMenu);
-void	sysmenu_init_subconfig(HWND hWnd, HMENU hMenu);
+//void	sysmenu_init_subconfig(HWND hWnd, HMENU hMenu);
 void	changeStateTopMostMenu(HWND hWnd, HMENU hMenu);
 
 void	sysmenu_init(HWND hWnd)
@@ -337,6 +337,7 @@ void	sysmenu_init_topmost(HWND hWnd, HMENU hMenu)
 	changeStateTopMostMenu(hWnd,hMenu);
 }
 
+/*
 void	sysmenu_init_subconfig(HWND hWnd, HMENU hMenu)
 {
 	MENUITEMINFO mii;
@@ -377,6 +378,7 @@ void	sysmenu_init_subconfig(HWND hWnd, HMENU hMenu)
 	mii.cch = (UINT) wcslen(mii.dwTypeData);
 	InsertMenuItem(hMenu, SC_CLOSE, FALSE, &mii);
 }
+*/
 
 void reloadConfig(wchar_t *path)
 {

--- a/misc.cpp
+++ b/misc.cpp
@@ -422,12 +422,12 @@ BOOL	onTopMostMenuCommand(HWND hWnd)
 	HMENU hMenu = GetSystemMenu(hWnd, FALSE);
 
 	UINT uState = GetMenuState( hMenu, IDM_TOPMOST, MF_BYCOMMAND);
-	DWORD dwExStyle = GetWindowLong(hWnd,GWL_EXSTYLE);
+	//DWORD dwExStyle = GetWindowLong(hWnd,GWL_EXSTYLE); // unused variable
 	if( uState & MFS_CHECKED )
 	{
-		SetWindowPos(hWnd, HWND_NOTOPMOST,NULL,NULL,NULL,NULL,SWP_NOMOVE | SWP_NOSIZE); 
+		SetWindowPos(hWnd, HWND_NOTOPMOST,0,0,0,0,SWP_NOMOVE | SWP_NOSIZE); 
 	}else{
-		SetWindowPos(hWnd, HWND_TOPMOST,NULL,NULL,NULL,NULL,SWP_NOMOVE | SWP_NOSIZE); 
+		SetWindowPos(hWnd, HWND_TOPMOST,0,0,0,0,SWP_NOMOVE | SWP_NOSIZE); 
 	}
 
 	changeStateTopMostMenu(hWnd, hMenu);

--- a/misc.cpp
+++ b/misc.cpp
@@ -18,7 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *---------------------------------------------------------------------------*/
-
+#define _CRT_SECURE_NO_WARNINGS 1
 #include <string>
 
 #include "ckw.h"
@@ -383,6 +383,7 @@ void	sysmenu_init_subconfig(HWND hWnd, HMENU hMenu)
 void reloadConfig(wchar_t *path)
 {
 	char filepath[MAX_PATH+1];
+	if(wcstombs(NULL, path, 0) + 1 > sizeof(filepath) / sizeof(filepath[0])) return;
 	wcstombs(filepath, path, MAX_PATH);
 
 	ckOpt opt;

--- a/option.cpp
+++ b/option.cpp
@@ -21,6 +21,7 @@
 #include "option.h"
 #include "version.h"
 #include <shlwapi.h>
+#include <stdio.h>
 
 static bool lookupColor(const char *str, COLORREF& ret)
 {
@@ -771,10 +772,11 @@ static bool lookupColor(const char *str, COLORREF& ret)
 
 	if(*str == '#') {
 		char	format[256];
+		int	format_size = sizeof(format) / sizeof(format[0]);
 		int	span = (int)(strlen(str)-1) / 3;
 		int	r, g, b;
-		sprintf_s(format, "%%%dx%%%dx%%%dx", span, span, span);
-		if(sscanf_s(str+1, format, &r, &g, &b) == 3) {
+		int format_ret = _snprintf(format, format_size, "%%%dx%%%dx%%%dx", span, span, span);
+		if(format_ret >= 0 && format_ret < format_size && sscanf(str+1, format, &r, &g, &b) == 3) {
 			if(span < 2) {
 				r <<= 4;
 				g <<= 4;
@@ -1036,7 +1038,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 
 
 	unsigned int i;
-	if(sscanf_s(name, "color%u", &i)==1 && 0<=i && i<=15) {
+	if(sscanf(name, "color%u", &i)==1 && 0<=i && i<=15) {
 		if(!value) return(0);
 		lookupColor(value, m_colors[i]);
 		return(2);
@@ -1115,7 +1117,7 @@ void	ckOpt::_loadXdefaults(const char *path)
 	FILE	*fp;
 	std::string app, name, value;
 
-	fopen_s(&fp, path, "r");
+	fp = fopen(path, "r");
 	if(!fp) return;
 
 	do {
@@ -1138,9 +1140,9 @@ void	ckOpt::_loadXdefaults(const char *path)
 
 void	ckOpt::setFile(const char *path /*=NULL*/)
 {
-    if(path)
+    if(path && strlen(path) + 1 <= sizeof(m_config_file) / sizeof(m_config_file[0]))
     {
-        strcpy_s(m_config_file, path);
+        strcpy(m_config_file, path);
     } else
     {
         m_config_file[0] = '\0';
@@ -1150,7 +1152,11 @@ void	ckOpt::setFile(const char *path /*=NULL*/)
 static bool getconfigfile(const char* env, char *cfgfile, char *path, int size)
 {
 	if(GetEnvironmentVariableA(env, path, size)) {
-		sprintf_s(path, size, "%s\\%s", path, cfgfile);
+		int format_ret =_snprintf(path, size, "%s\\%s", path, cfgfile);
+		if(format_ret < 0 || format_ret >= size) {
+			if(size > 0) path[0] = '\0';
+			return false;
+		}
 		if(PathFileExistsA(path) && !PathIsDirectoryA(path)) {
 			return true;
 		}
@@ -1167,36 +1173,42 @@ void ckOpt::loadXdefaults()
     char cfgfile[MAX_PATH] = "_";
 
     if (0 != GetModuleFileNameA(NULL, path, MAX_PATH)) {
-		char szDrive[MAX_PATH];
-		char szDir[MAX_PATH];
-		char szFile[MAX_PATH];
-		char szBuf[MAX_PATH];
-		_splitpath_s(path, szDrive, szDir, szFile, szBuf);
-		strcat_s(cfgfile, szFile);
+		char szDrive[_MAX_DRIVE];
+		char szDir[_MAX_DIR];
+		char szFile[_MAX_FNAME];
+		char szBuf[_MAX_EXT];
+		_splitpath(path, szDrive, szDir, szFile, szBuf);
 
-		path[0] = '\0';
-		// HOME or USERPROFILE
-		if (!getconfigfile("HOME", cfgfile, path, MAX_PATH)) {
-		  getconfigfile("USERPROFILE", cfgfile, path, MAX_PATH);
+		if(strlen(cfgfile) + strlen(szFile) + 1 <= sizeof(cfgfile) / sizeof(cfgfile[0])) {
+			strcat(cfgfile, szFile);
+
+			path[0] = '\0';
+			// HOME or USERPROFILE
+			if (!getconfigfile("HOME", cfgfile, path, MAX_PATH)) {
+			  getconfigfile("USERPROFILE", cfgfile, path, MAX_PATH);
+			}
+			if (path[0] != '\0') _loadXdefaults(path);
+
+			// directory execute exists
+			_makepath(path, szDrive, szDir, cfgfile, NULL);
+			_loadXdefaults(path);
+			_makepath(path, szDrive, szDir, szFile, ".cfg");
+			_loadXdefaults(path);
 		}
-		if (path[0] != '\0') _loadXdefaults(path);
-
-		// directory execute exists
-		_makepath_s(path, szDrive, szDir, cfgfile, NULL);
-		_loadXdefaults(path);
-		_makepath_s(path, szDrive, szDir, szFile, ".cfg");
-		_loadXdefaults(path);
     }
   }
   else
   {
     path[0] = '\0';
-    strcpy_s(path, m_config_file);
-    _loadXdefaults(path);
+    if(strlen(m_config_file) + 1 <= sizeof(path) / sizeof(path[0])) {
+      strcpy(path, m_config_file);
+      _loadXdefaults(path);
+    }
   }
 
-  if(GetEnvironmentVariableA("HOME", path, MAX_PATH)) {
-    strcat_s(path, "\\.Xdefaults");
+  const char *Xdefaults = "\\.Xdefaults";
+  if(GetEnvironmentVariableA("HOME", path, MAX_PATH) && strlen(path) + strlen(Xdefaults) + 1 <= sizeof(path) / sizeof(path[0])) {
+    strcat(path, Xdefaults);
     _loadXdefaults(path);
   }
 }

--- a/option.cpp
+++ b/option.cpp
@@ -18,6 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *---------------------------------------------------------------------------*/
+#define _CRT_SECURE_NO_WARNINGS 1
 #include "option.h"
 #include "version.h"
 #include <shlwapi.h>

--- a/option.cpp
+++ b/option.cpp
@@ -27,7 +27,7 @@ static bool lookupColor(const char *str, COLORREF& ret)
 {
 	typedef struct {
 		COLORREF	color;
-		char		*name;
+		const char	*name;
 	} COLOR;
 	static const COLOR colors[] = {
 		{ RGB(0xF0,0xF8,0xFF), "alice blue" },
@@ -1038,7 +1038,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 
 
 	unsigned int i;
-	if(sscanf(name, "color%u", &i)==1 && 0<=i && i<=15) {
+	if(sscanf(name, "color%u", &i)==1 && i<=15) {
 		if(!value) return(0);
 		lookupColor(value, m_colors[i]);
 		return(2);

--- a/selection.cpp
+++ b/selection.cpp
@@ -18,6 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *---------------------------------------------------------------------------*/
+#define _CRT_SECURE_NO_WARNINGS 1
 #include "ckw.h"
 
 static int	gSelectMode = 0;


### PR DESCRIPTION
makefile-gcc などを修正し GCC でビルドできるようにしました。(GCC 4.6.2 にて確認)

GCC でもビルドできるようにするため、[Visual C++ の _s 付き関数](http://msdn.microsoft.com/ja-jp/library/8ef0s5kh.aspx) を標準 C ライブラリにある関数に置き換え、警告が出ないように _CRT_SECURE_NO_WARNINGS を定義しています。

また、GCC でビルドした際に出た警告を出来る限り修正しています。
