### PR TITLE
Add BackgroundBitMapPos option.

### DIFF
--- a/ckw.cfg
+++ b/ckw.cfg
@@ -43,3 +43,7 @@ Ckw*color12: #FF0000
 Ckw*color13: #FF00FF
 Ckw*color14: #FFFF00
 Ckw*color15: #FFFFFF
+
+! 0:tile 1:left-top 2:right-top 3:left-bottom 4:right-bottom
+! 5:stretch-h 6:streach-v 7:stretch-fill
+!Ckw*backgroundBitmapPos: 0

--- a/option.cpp
+++ b/option.cpp
@@ -971,6 +971,7 @@ ckOpt::ckOpt()
 	m_transpColor = 0;
 	m_isTopMost = false;
 	m_config_file[0] = '\0';
+	m_bgBmpPos = 0;
 }
 
 ckOpt::~ckOpt()
@@ -1033,6 +1034,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 	CHK_MISC("exec",		"x",		m_cmd = value);
 	CHK_MISC("title",		"tl",		m_title = value);
 	CHK_MISC("config",		"c",		setFile(value);loadXdefaults() );
+	CHK_MISC("backgroundBitmapPos",	"bitmappos",	m_bgBmpPos = atoi(value));
 
 
 	unsigned int i;
@@ -1085,6 +1087,7 @@ static void usage(bool isLong)
 	"exec",			"x",		"string",	"exec shell",
 	"title",		"tl",		"string",	"window title",
 	"config",		"c",		"string",	"configration file",
+	"backgroundBitmapPos",	"bitmappos",	"number",	"background bmp position. ( 0:tile 1:left-top 2:right-top 3:left-bottom 4:right-bottom 5:stretch-h 6:stretch-v 7:stretch-fill )",
 	};
 	unsigned int	i;
 

--- a/option.h
+++ b/option.h
@@ -38,6 +38,7 @@ public:
 	bool		isTranspColor()		{ return(m_isTranspColor); }
 	COLORREF	getTranspColor()	{ return(m_transpColor); }
 	bool		isTopMost()		{ return(m_isTopMost); }
+	int		getBgBmpPos()		{ return(m_bgBmpPos); }
 
 	const char*	getCmd()
 	{
@@ -101,6 +102,7 @@ private:
 	std::string	m_curDir;
 	std::string	m_title;
 	char	m_config_file[MAX_PATH+1];
+	int		m_bgBmpPos;
 };
 
 #endif /* __CK_OPT_H__ */


### PR DESCRIPTION
背景画像を四隅や伸縮して表示を行えるように以下の設定を追加
- 背景表示位置 backgroundBitmapPos (default: 0)
  1. タイル
  2. 左上
  3. 右上
  4. 左下
  5. 右下
  6. 画面の幅に合わせて伸縮
  7. 画面の高さに合わせて伸縮
  8. 画面いっぱいに伸縮

宜しくお願いします

> 余談
> 数値で設定なのとonPaint内で座標計算してるのが微妙にアレ
