### PR TITLE
fix for gcc build

### DIFF
--- a/ckw.h
+++ b/ckw.h
@@ -8,6 +8,10 @@
 #include <windows.h>
 #include <wchar.h>
 
+#ifndef _MSC_VER
+#include "compat.h"
+#endif
+
 #ifdef _MSC_VER
 #define strcasecmp _stricmp
 #endif

--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,21 @@
+#ifndef __COMPAT_H__
+#define __COMPAT_H__ 1
+
+#include <stdio.h>
+
+#define _makepath_s _makepath
+#define _splitpath_s _splitpath
+#define sprintf_s snprintf
+#define sscanf_s sscanf
+#define strcat_s strcat
+#define strcpy_s strcpy
+#define wcscat_s wcscat
+
+inline int
+fopen_s(FILE** pFile, const char *filename, const char *mode)
+{
+  *pFile = fopen(filename, mode);
+  return 0;
+}
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -963,6 +963,10 @@ static BOOL create_font(const char* name, int height)
 #include <winternl.h>
 #endif
 
+#ifndef _MSC_VER // for gcc
+#include <ddk/ntapi.h>
+#endif
+
 /*----------*/
 static void __hide_alloc_console()
 {
@@ -1007,11 +1011,13 @@ static void __hide_alloc_console()
 
 	/* check */
 	if(si.dwFlags == backup_flags && si.wShowWindow == backup_show) {
+#ifdef _MSC_VER
 		// è⁄ç◊ÇÕïsñæÇæÇ™STARTF_TITLEISLINKNAMEÇ™óßÇ¡ÇƒÇ¢ÇÈÇ∆ÅA
 		// ConsoleëãâBÇµÇ…é∏îsÇ∑ÇÈÇÃÇ≈èúãé(Win7-64bit)
 		if (*pflags & STARTF_TITLEISLINKNAME) {
 			*pflags &= ~STARTF_TITLEISLINKNAME;
 		}
+#endif
 		*pflags |= STARTF_USESHOWWINDOW;
 		*pshow  = SW_HIDE;
 		bResult = true;
@@ -1270,7 +1276,7 @@ static void _terminate()
 #endif
 
 /*----------*/
-int APIENTRY wWinMain(HINSTANCE hInst, HINSTANCE hPrev, LPWSTR lpCmdLine, int nCmdShow)
+int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmdLine, int nCmdShow)
 {
 #ifdef _DEBUG
 	char *a = new char[1];

--- a/makefile-gcc
+++ b/makefile-gcc
@@ -1,58 +1,62 @@
-BIN     = ckw.exe
-RES     = rsrc.res
-RM      = rm
-OBJ     = main.o \
-          option.o \
-          selection.o \
-          ime_wrap.o \
-          misc.o
+DEBUG =
 
-DEFINES = -DNDEBUG -Dwcscat_s=wcscat
-# --------------------------------------------------------------------
+BIN = ckw.exe
+CXX = g++
+RC = windres
+RM = rm
+INCLUDE  =
+CXXFLAGS = -O2 $(INCLUDE) \
+           -fno-rtti \
+           -fno-exceptions \
+           -fomit-frame-pointer
+LDFLAGS = -mwindows -Wl,--enable-stdcall-fixup -static -s
+LDLIBS = -lshlwapi
+RFLAGS = -J rc -O coff
 
-ifdef INSTDIR
-all: $(INSTDIR)\$(BIN)
-else
-all: $(BIN)
+ifdef DEBUG
+CXXFLAGS = -g -Wall -Wextra $(INCLUDE)
+LDFLAGS = -mwindows -Wl,--enable-stdcall-fixup -static
+LDLIBS = -lshlwapi
 endif
 
-$(INSTDIR)\$(BIN): $(BIN)
-	command.com /c copy $(BIN) $(INSTDIR)
+SRCS = ime_wrap.cpp \
+       main.cpp \
+       misc.cpp \
+       option.cpp \
+       selection.cpp
+OBJS = $(SRCS:.cpp=.o) rsrc.res
+
+.SUFFIXES:
+.SUFFIXES: .o .cpp .res .rc
+
+.PHONY: all clean depend
+
+# --------------------------------------------------------------------
+
+all: ver $(BIN)
+
+ver:
+	cmd /c version.bat > version.h
+
+depend:
+	$(CXX) -MM $(CXXFLAGS) $(SRCS) > depend.txt
+	@echo
+	@cat depend.txt
 
 clean:
-	$(RM) -f $(OBJ) $(RES) $(BIN)
-
-CC      = gcc.exe
-CP      = g++.exe
-WINDRES = windres.exe -J rc -O coff --include-dir $(<D)
-CFLAGS  = -Os -Wall \
-          -fno-rtti \
-          -fno-exceptions \
-          -fomit-frame-pointer \
-          -fmove-all-movables \
-          -c $(DEFINES)
-LFLAGS  =
-LOPTS   = -Wl,--entry,_wWinMain,--enable-stdcall-fixup
-LIBS    = -s -mwindows -nostartfiles
-
+	-$(RM) -f $(OBJS) $(BIN) *~
 
 # --------------------------------------------------------------------
 
-$(BIN): $(OBJ) $(RES) makefile-gcc
-	$(CP) $(LFLAGS) $(OBJ) $(RES) $(LIBS) $(LOPTS) -o $(BIN)
-
-depend.txt: $(patsubst %.o,%.cpp,$(OBJ))
-	$(CC) -MM $^ >$@
-
-# --------------------------------------------------------------------
-
-%.o: %.c
-	$(CC) $(CFLAGS) $< -o $@
+$(BIN): $(OBJS)
+	$(CXX) $(OBJS) -o $(BIN) $(LDFLAGS) $(LDLIBS)
 
 %.o: %.cpp
-	$(CP) $(CFLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 %.res: %.rc
-	$(WINDRES) -i $< -o $@
+	$(RC) $(RFLAGS) -i $< -o $@
 
 # --------------------------------------------------------------------
+
+sinclude depend.txt

--- a/option.cpp
+++ b/option.cpp
@@ -21,6 +21,7 @@
 #include "option.h"
 #include "version.h"
 #include <shlwapi.h>
+#include <stdio.h>
 
 static bool lookupColor(const char *str, COLORREF& ret)
 {
@@ -773,7 +774,7 @@ static bool lookupColor(const char *str, COLORREF& ret)
 		char	format[256];
 		int	span = (int)(strlen(str)-1) / 3;
 		int	r, g, b;
-		sprintf_s(format, "%%%dx%%%dx%%%dx", span, span, span);
+		sprintf_s(format, sizeof(format) / sizeof(format[0]), "%%%dx%%%dx%%%dx", span, span, span);
 		if(sscanf_s(str+1, format, &r, &g, &b) == 3) {
 			if(span < 2) {
 				r <<= 4;

--- a/rsrc.rc
+++ b/rsrc.rc
@@ -1,6 +1,6 @@
 #include "version.h"
 #include "rsrc.h"
-#include "winuser.h"
+#include <winresrc.h>
 
 IDR_ICON ICON  "rsrc/icon.ico"
 


### PR DESCRIPTION
#13, #14

極力 VC++ でのビルドに影響がない形で gcc でもビルドできるようにしました。
- MinGW の gcc 4.6.2
- MinGW-w64 の gcc (tdm64-1) 4.7.1

で確認しました。
