### PR TITLE
chdir オプションで指定したディレクトリが削除できない

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1243,6 +1243,18 @@ static BOOL initialize()
 		trace("create_child_process failed\n");
 		return(FALSE);
 	}
+	char exepath[MAX_PATH+1];
+	if (0 != GetModuleFileNameA(NULL, exepath, MAX_PATH)) {
+		char szDrive[MAX_PATH];
+		char szDir[MAX_PATH];
+		char szFile[MAX_PATH];
+		char szBuf[MAX_PATH];
+		_splitpath_s(exepath, szDrive, szDir, szFile, szBuf);
+		_makepath_s(exepath, szDrive, szDir, NULL, NULL);
+		if (! set_current_directory(exepath)) {
+			trace("set_current_directory failed\n");
+		}
+	}
 	if(! create_window(opt)) {
 		trace("create_window failed\n");
 		return(FALSE);


### PR DESCRIPTION
#20 の変更で ckw 自身のカレントディレクトリを変更するようにしたことにより、 ckw を終了するまで `chdir` オプションで指定したディレクトリが削除できなくなっています。

このパッチでは、子プロセスの起動直後にカレントディレクトリを ckw.exe があるディレクトリへ変更します。

これにより、ckw.exe があるディレクトリは基本的には実行中に削除できないため、問題を解決できます。
