### PR TITLE
GCC の警告を除去する

### DIFF
--- a/ime_wrap.cpp
+++ b/ime_wrap.cpp
@@ -39,7 +39,9 @@ HIMC WINAPI ImmGetContext(HWND hwnd)
 {
 	if(fn_GetContext)
 		return( fn_GetContext(hwnd) );
-	return(NULL);
+
+	HIMC imc = {0};
+	return(imc);
 }
 
 BOOL WINAPI ImmReleaseContext(HWND hwnd, HIMC imc)

--- a/main.cpp
+++ b/main.cpp
@@ -575,8 +575,8 @@ void	onTimer(HWND hWnd)
 		__set_ime_position(hWnd);
 	}
 
-	int w = CSI_WndCols(gCSI);
-	int h = CSI_WndRows(gCSI);
+	DWORD w = CSI_WndCols(gCSI);
+	DWORD h = CSI_WndRows(gCSI);
 	if(gWinW != w || gWinH != h) {
 		w = (w * gFontW) + (gBorderSize * 2) + (gFrame.right - gFrame.left);
 		h = (h * gFontH) + (gBorderSize * 2) + (gFrame.bottom - gFrame.top);
@@ -750,7 +750,7 @@ static BOOL create_window(ckOpt& opt)
 	trace("create_window\n");
 
 	HINSTANCE hInstance = GetModuleHandle(NULL);
-	LPWSTR	className = L"CkwWindowClass";
+	LPCWSTR	className = L"CkwWindowClass";
 	const char*	conf_icon;
 	WNDCLASSEX wc;
 	DWORD	style = WS_OVERLAPPEDWINDOW;

--- a/makefile-gcc
+++ b/makefile-gcc
@@ -14,7 +14,7 @@ LDLIBS = -lshlwapi
 RFLAGS = -J rc -O coff
 
 ifdef DEBUG
-CXXFLAGS = -g -Wall -Wextra $(INCLUDE)
+CXXFLAGS = -g -Wall -Wextra -Wno-unused-parameter $(INCLUDE)
 LDFLAGS = -mwindows -Wl,--enable-stdcall-fixup -static
 LDLIBS = -lshlwapi
 endif

--- a/misc.cpp
+++ b/misc.cpp
@@ -426,12 +426,12 @@ BOOL	onTopMostMenuCommand(HWND hWnd)
 	HMENU hMenu = GetSystemMenu(hWnd, FALSE);
 
 	UINT uState = GetMenuState( hMenu, IDM_TOPMOST, MF_BYCOMMAND);
-	DWORD dwExStyle = GetWindowLong(hWnd,GWL_EXSTYLE);
+	//DWORD dwExStyle = GetWindowLong(hWnd,GWL_EXSTYLE); // unused variable
 	if( uState & MFS_CHECKED )
 	{
-		SetWindowPos(hWnd, HWND_NOTOPMOST,NULL,NULL,NULL,NULL,SWP_NOMOVE | SWP_NOSIZE); 
+		SetWindowPos(hWnd, HWND_NOTOPMOST,0,0,0,0,SWP_NOMOVE | SWP_NOSIZE); 
 	}else{
-		SetWindowPos(hWnd, HWND_TOPMOST,NULL,NULL,NULL,NULL,SWP_NOMOVE | SWP_NOSIZE); 
+		SetWindowPos(hWnd, HWND_TOPMOST,0,0,0,0,SWP_NOMOVE | SWP_NOSIZE); 
 	}
 
 	changeStateTopMostMenu(hWnd, hMenu);

--- a/option.cpp
+++ b/option.cpp
@@ -27,7 +27,7 @@ static bool lookupColor(const char *str, COLORREF& ret)
 {
 	typedef struct {
 		COLORREF	color;
-		char		*name;
+		const char	*name;
 	} COLOR;
 	static const COLOR colors[] = {
 		{ RGB(0xF0,0xF8,0xFF), "alice blue" },

--- a/option.cpp
+++ b/option.cpp
@@ -1045,7 +1045,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 
 
 	unsigned int i;
-	if(sscanf_s(name, "color%u", &i)==1 && 0<=i && i<=15) {
+	if(sscanf_s(name, "color%u", &i)==1 && i<=15) {
 		if(!value) return(0);
 		lookupColor(value, m_colors[i]);
 		return(2);


### PR DESCRIPTION
GCC でビルドした際に警告される部分を修正します。型が違っている部分を修正しています。

`MENUITEMINFO` の `dwTypeData` に代入する部分でも -Wwrite-strings が発生していますが、これはキャストで const を外しても良いのか、それともちゃんとバッファを用意すべきなのかがわからないのでとりあえずそのままにしています。

(#13 の 警告除去部分の再 pull request です。)
