### PR TITLE
handle CTRL_CLOSE_EVENT

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1058,9 +1058,21 @@ static void __hide_alloc_console()
 	}
 }
 
+static void _terminate();
+
 /*----------*/
 BOOL WINAPI sig_handler(DWORD n)
 {
+	switch(n) {
+	case CTRL_CLOSE_EVENT:
+	case CTRL_LOGOFF_EVENT:
+	case CTRL_SHUTDOWN_EVENT:
+		_terminate();
+		ExitProcess(0);
+		break;
+	default:
+		break;
+	}
 	return(TRUE);
 }
 


### PR DESCRIPTION
southly/ckw-mod#3 の件です。

ckw-mod の閉じるボタンをクリックすると `sig_handler` に `CTRL_CLOSE_EVENT` がきて、その後終了コード `STATUS_CONTROL_C_EXIT(0xC000013A)` で終了しています。
たいしたことではないと思いますがデバッグしていて気になるので、`CTRL_CLOSE_EVENT` がきたら後始末として `_terminate` を呼びそこで終了してしまうようにしました。

閉じるボタンで異常終了するのは Win7 64bit のときで、Win XP 32bit では正常に終了していました。
