### PR TITLE
パス内の環境変数を展開するようにした

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -908,6 +908,10 @@ static BOOL create_child_process(const char* cmd)
 		strcpy(buf, cmd);
 	}
 
+	DWORD bufferSize = ExpandEnvironmentStringsA(buf, NULL, 0);
+	char* expandedCmd = new char[bufferSize];
+	ExpandEnvironmentStringsA(buf, expandedCmd, bufferSize);
+
 	PROCESS_INFORMATION pi;
 	STARTUPINFOA si;
 	memset(&si, 0, sizeof(si));
@@ -917,12 +921,14 @@ static BOOL create_child_process(const char* cmd)
 	si.hStdOutput = gStdOut;
 	si.hStdError  = gStdErr;
 
-	if(! CreateProcessA(NULL, buf, NULL, NULL, TRUE,
+	if(! CreateProcessA(NULL, expandedCmd, NULL, NULL, TRUE,
 			    0, NULL, NULL, &si, &pi)) {
 		delete [] buf;
+		delete [] expandedCmd;
 		return(FALSE);
 	}
 	delete [] buf;
+	delete [] expandedCmd;
 	CloseHandle(pi.hThread);
 	gChild = pi.hProcess;
 	return(TRUE);

--- a/main.cpp
+++ b/main.cpp
@@ -886,7 +886,7 @@ static BOOL set_current_directory(const char *dir)
 
 	BOOL b = SetCurrentDirectoryA(expandedCwd);
 
-	delete expandedCwd;
+	delete[] expandedCwd;
 	return b;
 }
 
@@ -1215,7 +1215,7 @@ BOOL init_options(ckOpt& opt)
 		gBgBmp = (HBITMAP)LoadImageA(NULL, expandedBmpPath,
 				IMAGE_BITMAP, 0,0, LR_LOADFROMFILE);
 
-		delete expandedBmpPath;
+		delete[] expandedBmpPath;
 	}
 	if(gBgBmp) {
 		gBgBmpPosOpt = opt.getBgBmpPos();

--- a/main.cpp
+++ b/main.cpp
@@ -879,8 +879,14 @@ static BOOL set_current_directory(const char *dir)
 		cwd.resize(index+1);
 		cwd[index] = '\\';
 	}
-	BOOL b = SetCurrentDirectoryA(cwd.c_str());
 
+	DWORD bufferSize = ExpandEnvironmentStringsA(cwd.c_str(), NULL, 0);
+	char* expandedCwd = new char[bufferSize];
+	ExpandEnvironmentStringsA(cwd.c_str(), expandedCwd, bufferSize);
+
+	BOOL b = SetCurrentDirectoryA(expandedCwd);
+
+	delete expandedCwd;
 	return b;
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1202,8 +1202,14 @@ BOOL init_options(ckOpt& opt)
 	gLineSpace = opt.getLineSpace();
 
 	if(opt.getBgBmp()) {
-		gBgBmp = (HBITMAP)LoadImageA(NULL, opt.getBgBmp(),
+		DWORD bufferSize = ExpandEnvironmentStringsA(opt.getBgBmp(), NULL, 0);
+		char* expandedBmpPath = new char[bufferSize];
+		ExpandEnvironmentStringsA(opt.getBgBmp(), expandedBmpPath, bufferSize);
+
+		gBgBmp = (HBITMAP)LoadImageA(NULL, expandedBmpPath,
 				IMAGE_BITMAP, 0,0, LR_LOADFROMFILE);
+
+		delete expandedBmpPath;
 	}
 	if(gBgBmp) {
 		gBgBmpPosOpt = opt.getBgBmpPos();


### PR DESCRIPTION
```
Ckw*chdir: %USERPROFILE%
Ckw*backgroundBitmap: %USERPROFILE%\Pictures\gosongan.bmp
Ckw*exec:  %USERPROFILE%\Apps\ckw\nyaos.exe
```

みたいなことができるようになりました。
#21 が落ち着いてからがいいかなとも思ったんですが、とりあえず...

目についたパス系の設定は以上の3つだったんですが、もし漏れがあったらすみません。
