### PR TITLE
背景画像にBMP以外も使えるようにした

### DIFF
--- a/image.cpp
+++ b/image.cpp
@@ -1,0 +1,127 @@
+/*-----------------------------------------------------------------------------
+ * File: image.cpp
+ *-----------------------------------------------------------------------------
+ * Copyright (c) 2013       mecab <mecab@misosi.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ *-----------------------------------------------------------------------------
+ * Portions are originally under MIT License
+ *-----------------------------------------------------------------------------
+ * Copyright 2007-2008 Logos Bible Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *---------------------------------------------------------------------------*/
+
+#include "image.h"
+#include <wincodec.h>
+#include <wincodecsdk.h>
+
+IWICBitmapSource* CreateBitmapSourceFromFile(LPCSTR lpname)
+{
+	HRESULT hr;
+	size_t wbufSize = MultiByteToWideChar(CP_OEMCP, MB_PRECOMPOSED, lpname, -1, NULL, 0);
+	LPWSTR wstr = new WCHAR[wbufSize];
+	MultiByteToWideChar(CP_OEMCP, MB_PRECOMPOSED, lpname, -1, wstr, wbufSize);
+
+	IWICImagingFactory* wicFactory = NULL;
+	IWICBitmapDecoder* decoder = NULL;
+	IWICBitmapFrameDecode* frame = NULL;
+	IWICBitmapSource* ipBitmap = NULL;
+
+	hr = CoCreateInstance(CLSID_WICImagingFactory, NULL, CLSCTX_INPROC_SERVER, IID_IWICImagingFactory, reinterpret_cast<LPVOID *>(&wicFactory));
+	if(SUCCEEDED(hr)) {
+		hr = wicFactory->CreateDecoderFromFilename(wstr, NULL, GENERIC_READ, WICDecodeMetadataCacheOnLoad, &decoder);
+	}
+	if(SUCCEEDED(hr)) {
+		hr = decoder->GetFrame(0, &frame);
+	}
+	if(SUCCEEDED(hr)) {
+		// convert the image to 32bpp BGRA format with pre-multiplied alpha
+		// (it may not be stored in that format natively in the PNG resource,
+		// but we need this format to create the DIB to use on-screen)
+		hr = WICConvertBitmapSource(GUID_WICPixelFormat32bppPBGRA, frame, &ipBitmap);
+	}
+
+	delete[] wstr;
+	if (frame) {
+		frame->Release();
+	}
+	if (decoder) {
+		decoder->Release();
+	}
+	if (wicFactory) {
+		wicFactory->Release();
+	}
+
+	return ipBitmap;
+ }
+
+HBITMAP CreateHBITMAPFromBitmapSource(IWICBitmapSource * ipBitmap)
+{
+    // initialize return value
+    HBITMAP hbmp = NULL;
+
+    // get image attributes and check for valid image
+    UINT width = 0;
+    UINT height = 0;
+    if (FAILED(ipBitmap->GetSize(&width, &height)) || width == 0 || height == 0)
+        return NULL;
+
+    // prepare structure giving bitmap information (negative height indicates a top-down DIB)
+    BITMAPINFO bminfo;
+    ZeroMemory(&bminfo, sizeof(bminfo));
+    bminfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bminfo.bmiHeader.biWidth = width;
+    bminfo.bmiHeader.biHeight = -((LONG) height);
+    bminfo.bmiHeader.biPlanes = 1;
+    bminfo.bmiHeader.biBitCount = 32;
+    bminfo.bmiHeader.biCompression = BI_RGB;
+
+    // create a DIB section that can hold the image
+    void * pvImageBits = NULL;
+    HDC hdcScreen = GetDC(NULL);
+    hbmp = CreateDIBSection(hdcScreen, &bminfo, DIB_RGB_COLORS, &pvImageBits, NULL, 0);
+    ReleaseDC(NULL, hdcScreen);
+    if (hbmp == NULL)
+        return NULL;
+
+    // extract the image into the HBITMAP
+    const UINT cbStride = width * 4;
+    const UINT cbImage = cbStride * height;
+    if (FAILED(ipBitmap->CopyPixels(NULL, cbStride, cbImage, static_cast<BYTE *>(pvImageBits))))
+    {
+        // couldn't extract image; delete HBITMAP
+        DeleteObject(hbmp);
+        hbmp = NULL;
+    }
+
+	return hbmp;
+}

--- a/image.h
+++ b/image.h
@@ -1,0 +1,9 @@
+#ifndef __CWK_IMAGE_H__
+#define __CWK_IMAGE_H__ 1
+
+#include "ckw.h"
+#include <wincodec.h>
+IWICBitmapSource* CreateBitmapSourceFromFile(LPCSTR lpname);
+HBITMAP CreateHBITMAPFromBitmapSource(IWICBitmapSource* ipBitmap);
+
+#endif /* __CKW_IMAGE_H__ */

--- a/image.h
+++ b/image.h
@@ -3,7 +3,9 @@
 
 #include "ckw.h"
 #include <wincodec.h>
-IWICBitmapSource* CreateBitmapSourceFromFile(LPCSTR lpname);
-HBITMAP CreateHBITMAPFromBitmapSource(IWICBitmapSource* ipBitmap);
+HBITMAP createHBITMAPFromFile(LPCSTR path);
+BOOL isOSGreaterThan2k();
+IWICBitmapSource* createBitmapSourceFromFile(LPCSTR lpname);
+HBITMAP createHBITMAPFromBitmapSource(IWICBitmapSource* ipBitmap);
 
 #endif /* __CKW_IMAGE_H__ */

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *---------------------------------------------------------------------------*/
 #include "ckw.h"
+#include "image.h"
 #include "rsrc.h"
 #include <imm.h>
 
@@ -1196,8 +1197,11 @@ BOOL init_options(ckOpt& opt)
 	gLineSpace = opt.getLineSpace();
 
 	if(opt.getBgBmp()) {
-		gBgBmp = (HBITMAP)LoadImageA(NULL, opt.getBgBmp(),
-				IMAGE_BITMAP, 0,0, LR_LOADFROMFILE);
+		IWICBitmapSource *bitmapSource = CreateBitmapSourceFromFile(opt.getBgBmp());
+		if (bitmapSource) {
+			gBgBmp = CreateHBITMAPFromBitmapSource(bitmapSource);
+			bitmapSource->Release();
+		}
 	}
 	if(gBgBmp) {
 		gBgBmpPosOpt = opt.getBgBmpPos();
@@ -1317,6 +1321,7 @@ int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmdLine, int nCmd
 	_CrtSetReportFile( _CRT_ERROR,  _CRTDBG_FILE_STDERR );
 #endif
 
+	CoInitialize(NULL);
 	if(initialize()) {
 		MSG msg;
 		while(GetMessage(&msg, NULL, 0,0)) {
@@ -1325,6 +1330,7 @@ int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmdLine, int nCmd
 		}
 	}
 	_terminate();
+	CoUninitialize();
 	return(0);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1197,11 +1197,7 @@ BOOL init_options(ckOpt& opt)
 	gLineSpace = opt.getLineSpace();
 
 	if(opt.getBgBmp()) {
-		IWICBitmapSource *bitmapSource = CreateBitmapSourceFromFile(opt.getBgBmp());
-		if (bitmapSource) {
-			gBgBmp = CreateHBITMAPFromBitmapSource(bitmapSource);
-			bitmapSource->Release();
-		}
+		gBgBmp = createHBITMAPFromFile(opt.getBgBmp());
 	}
 	if(gBgBmp) {
 		gBgBmpPosOpt = opt.getBgBmpPos();

--- a/vc2010/ckw.vcxproj
+++ b/vc2010/ckw.vcxproj
@@ -105,7 +105,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shlwapi.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;windowscodecs.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
@@ -127,7 +127,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shlwapi.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;windowscodecs.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -153,7 +153,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
@@ -178,7 +178,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -189,6 +189,7 @@
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\image.cpp" />
     <ClCompile Include="..\main.cpp" />
     <ClCompile Include="..\misc.cpp" />
     <ClCompile Include="..\option.cpp" />
@@ -196,6 +197,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ckw.h" />
+    <ClInclude Include="..\image.h" />
     <ClInclude Include="..\option.h" />
     <ClInclude Include="..\rsrc.h" />
     <ClInclude Include="..\version.h" />


### PR DESCRIPTION
Windows Imaging Component (WIC)を使って背景画像を読み込むようにしてみました。

ということでVista以降とWICを導入したXPで基本的なフォーマットの画像が背景に使えるようになりました。地味に需要あるんじゃないかなーと思います。

そもそもWICを導入できないW2kでは以前のルーチンで読み込むようにしたのですが、WICを未導入のXPではどのような挙動をするか確認できておりません...
