### PR TITLE
フォントスペースのオプション追加

### DIFF
--- a/ckw.cfg
+++ b/ckw.cfg
@@ -21,6 +21,7 @@ Ckw*topmost: no
 !Ckw*transpColor: #000000
 
 Ckw*font: MS Gothic
+Ckw*fontSpace: 0
 Ckw*fontSize: 12
 
 Ckw*geometry:  80x26

--- a/main.cpp
+++ b/main.cpp
@@ -55,6 +55,8 @@ POINT	gBgBmpSize = { 0, 0 };
 BOOL	gCurBlink = FALSE;
 BOOL	gCurHide = FALSE;
 
+int     gFontSpace = 0;
+
 /* screen buffer - copy */
 CONSOLE_SCREEN_BUFFER_INFO* gCSI = NULL;
 CHAR_INFO*	gScreen = NULL;
@@ -314,7 +316,7 @@ static void __draw_screen(HDC hDC)
 		ptr = gScreen + CSI_WndCols(gCSI) * pntY + pntX;
 		pntX *= gFontW;
 		pntY *= gFontH;
-		*work_width = (ptr->Attributes & COMMON_LVB_LEADING_BYTE) ? gFontW*2 : gFontW;
+		*work_width = (ptr->Attributes & COMMON_LVB_LEADING_BYTE) ? (gFontW - gFontSpace)*2 : (gFontW - gFontSpace);
 		ExtTextOut(hDC, pntX, pntY, 0, NULL,
 			   &ptr->Char.UnicodeChar, 1, work_width);
 	}
@@ -964,7 +966,7 @@ static BOOL create_font(const char* name, int height)
 		width += width2[i];
 	}
 	width /= 26 * 2;
-	gFontW = width; /* met.tmAveCharWidth; */
+	gFontW = width + gFontSpace; /* met.tmAveCharWidth; */
 	gFontH = met.tmHeight + gLineSpace;
 
 	return(TRUE);
@@ -1212,6 +1214,8 @@ BOOL init_options(ckOpt& opt)
 		ZeroMemory(gTitle, sizeof(wchar_t) * (strlen(conf_title)+1));
 		MultiByteToWideChar(CP_ACP, 0, conf_title, (int)strlen(conf_title), gTitle, (int)(sizeof(wchar_t) * (strlen(conf_title)+1)) );
 	}
+
+	gFontSpace = opt.getFontSpace();
 
 	return(TRUE);
 }

--- a/option.cpp
+++ b/option.cpp
@@ -942,6 +942,7 @@ ckOpt::ckOpt()
 	m_winCharH = 24;
 	m_isIconic = false;
 	m_fontSize = 14;
+	m_fontSpace = 0;
 	m_colors[0]  = RGB(0x00, 0x00, 0x01);
 	m_colors[1]  = RGB(0x00, 0x00, 0x80);
 	m_colors[2]  = RGB(0x00, 0x80, 0x00);
@@ -1028,6 +1029,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 	CHK_BOOL(NULL, 			"iconic",	m_isIconic);
 	CHK_MISC("font",		"fn",		m_font = value);
 	CHK_MISC("fontSize",		"fs",		m_fontSize = atoi(value));
+	CHK_MISC("fontSpace",		"fsp",		m_fontSpace = atoi(value));
 	CHK_BOOL("scrollHide",		"sh",		m_scrollHide);
 	CHK_BOOL("scrollRight",		"sr",		m_scrollRight);
 	CHK_MISC("saveLines",		"sl",		m_saveLines = atoi(value));

--- a/option.h
+++ b/option.h
@@ -48,6 +48,7 @@ public:
 		return((m_cmd.size()) ? m_cmd.c_str() : NULL);
 	}
 	int		getFontSize()		{ return(m_fontSize); }
+	int		getFontSpace()		{ return(m_fontSpace); }
 	const char*	getFont()
 	{
 		return((m_font.size()) ? m_font.c_str() : NULL);
@@ -86,6 +87,7 @@ private:
 	std::string	m_cmd;
 	std::string	m_font;
 	int		m_fontSize;
+	int		m_fontSpace;
 	COLORREF	m_colorFg;
 	COLORREF	m_colorBg;
 	COLORREF	m_colorCursor;


### PR DESCRIPTION
フォントによっては文字間隔が詰まって
見づらいことがあるので間隔を設定するオプションを追加してみたので
よろしければ取り込んでいただけないでしょうか？
