### PR TITLE
引数からディレクトリを遡って有効なパスを探す

### DIFF
--- a/option.cpp
+++ b/option.cpp
@@ -1002,6 +1002,41 @@ ckOpt::~ckOpt()
 		return(1); \
 	}
 
+#define IS_NPOS(pos) (std::string::npos == (pos))
+static bool getParentDir(std::string &strDest){
+	int slash = strDest.find_last_of("/", strDest.size()-2);
+	int bslash = strDest.find_last_of("\\", strDest.size()-2);
+
+	int pos;
+	if (!IS_NPOS(slash) && IS_NPOS(bslash))
+		pos = slash;
+	else if (IS_NPOS(slash) && !IS_NPOS(bslash))
+		pos = bslash;
+	else
+		pos = max(slash, bslash);
+
+	if (!IS_NPOS(pos)){
+		strDest.erase(pos+1);
+		return true;
+	}
+	else{
+		return false;
+	}
+}
+
+static std::string getValidDir(LPCSTR value){
+	std::string strDir = value;
+
+	// replace double-quotation to backslash
+	if (!strDir.empty() && (strDir.at(strDir.size()-1) == '\"'))
+		strDir.replace(strDir.end()-1, strDir.end(), "\\");
+
+	// trace back to valid directory
+	while (!PathIsDirectoryA(strDir.c_str()) && getParentDir(strDir));
+
+	return strDir;
+}
+
 int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 {
 	bool	flagSW = true;
@@ -1036,7 +1071,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 	CHK_MISC("transp",		"tr",		m_transp = atoi(value));
 	CHK_MISC("transpColor",		"trc",		m_isTranspColor = lookupColor(value,m_transpColor));
 	CHK_BOOL("topmost",		"top",		m_isTopMost);
-	CHK_MISC("chdir",		"cd",		m_curDir = value);
+	CHK_MISC("chdir",		"cd",		m_curDir = getValidDir(value));
 	CHK_MISC("exec",		"x",		m_cmd = value);
 	CHK_MISC("title",		"tl",		m_title = value);
 	CHK_MISC("config",		"c",		setFile(value);loadXdefaults() );


### PR DESCRIPTION
-cdのオプションの引数から親ディレクトリを辿って有効なパスを捜すパッチです。
ファイルパスを与えられた時に、そのファイルがあるディレクトリでckwを開けるので
ファイラ等へのショートカットに登録時便利かと思いますので
検討お願いします。
