### PR TITLE
add fontSpace option

### DIFF
--- a/ckw.cfg
+++ b/ckw.cfg
@@ -21,6 +21,7 @@ Ckw*topmost: no
 !Ckw*transpColor: #000000
 
 Ckw*font: MS Gothic
+Ckw*fontSpace: 0
 Ckw*fontSize: 12
 
 Ckw*geometry:  80x26

--- a/main.cpp
+++ b/main.cpp
@@ -57,6 +57,8 @@ DWORD	gCurBlinkNext = 0;
 BOOL	gCurHide = FALSE;
 BOOL	gFocus = FALSE;
 
+int     gFontSpace = 0;
+
 /* screen buffer - copy */
 CONSOLE_SCREEN_BUFFER_INFO* gCSI = NULL;
 CHAR_INFO*	gScreen = NULL;
@@ -312,7 +314,7 @@ static void __draw_screen(HDC hDC)
 		ptr = gScreen + CSI_WndCols(gCSI) * pntY + pntX;
 		pntX *= gFontW;
 		pntY *= gFontH;
-		*work_width = (ptr->Attributes & COMMON_LVB_LEADING_BYTE) ? gFontW*2 : gFontW;
+		*work_width = (ptr->Attributes & COMMON_LVB_LEADING_BYTE) ? (gFontW - gFontSpace)*2 : (gFontW - gFontSpace);
 		if(!gFocus){
 			HPEN hPen = CreatePen(PS_SOLID, 1, gColorTable[ color_bg ]);
 			HPEN hOldPen = (HPEN)SelectObject(hDC, hPen);
@@ -983,7 +985,7 @@ static BOOL create_font(const char* name, int height)
 		width += width2[i];
 	}
 	width /= 26 * 2;
-	gFontW = width; /* met.tmAveCharWidth; */
+	gFontW = width + gFontSpace; /* met.tmAveCharWidth; */
 	gFontH = met.tmHeight + gLineSpace;
 
 	return(TRUE);
@@ -1243,6 +1245,8 @@ BOOL init_options(ckOpt& opt)
 		ZeroMemory(gTitle, sizeof(wchar_t) * (strlen(conf_title)+1));
 		MultiByteToWideChar(CP_ACP, 0, conf_title, (int)strlen(conf_title), gTitle, (int)(sizeof(wchar_t) * (strlen(conf_title)+1)) );
 	}
+
+	gFontSpace = opt.getFontSpace();
 
 	return(TRUE);
 }

--- a/option.cpp
+++ b/option.cpp
@@ -942,6 +942,7 @@ ckOpt::ckOpt()
 	m_winCharH = 24;
 	m_isIconic = false;
 	m_fontSize = 14;
+	m_fontSpace = 0;
 	m_colors[0]  = RGB(0x00, 0x00, 0x01);
 	m_colors[1]  = RGB(0x00, 0x00, 0x80);
 	m_colors[2]  = RGB(0x00, 0x80, 0x00);
@@ -1028,6 +1029,7 @@ int	ckOpt::setOption(const char *name, const char *value, bool rsrc)
 	CHK_BOOL(NULL, 			"iconic",	m_isIconic);
 	CHK_MISC("font",		"fn",		m_font = value);
 	CHK_MISC("fontSize",		"fs",		m_fontSize = atoi(value));
+	CHK_MISC("fontSpace",		"fsp",		m_fontSpace = atoi(value));
 	CHK_BOOL("scrollHide",		"sh",		m_scrollHide);
 	CHK_BOOL("scrollRight",		"sr",		m_scrollRight);
 	CHK_MISC("saveLines",		"sl",		m_saveLines = atoi(value));
@@ -1084,6 +1086,7 @@ static void usage(bool isLong)
 	NULL, 			"iconic",	"boolean",	"start iconic",
 	"font",			"fn",		"string",	"text font name",
 	"fontSize",		"fs",		"number",	"text font size",
+	"fontSpace",		"fsp",		"number",	"number of extra pixels between characters",
 	"scrollHide",		"sh",		"boolean",	"turn on/off scrollbar hide",
 	"scrollRight",		"sr",		"boolean",	"turn on/off scrollbar right",
 	"saveLines",		"sl",		"number",	"save lines",

--- a/option.h
+++ b/option.h
@@ -48,6 +48,7 @@ public:
 		return((m_cmd.size()) ? m_cmd.c_str() : NULL);
 	}
 	int		getFontSize()		{ return(m_fontSize); }
+	int		getFontSpace()		{ return(m_fontSpace); }
 	const char*	getFont()
 	{
 		return((m_font.size()) ? m_font.c_str() : NULL);
@@ -86,6 +87,7 @@ private:
 	std::string	m_cmd;
 	std::string	m_font;
 	int		m_fontSize;
+	int		m_fontSpace;
 	COLORREF	m_colorFg;
 	COLORREF	m_colorBg;
 	COLORREF	m_colorCursor;


### PR DESCRIPTION
文字間のスペースを設定するオプション `-fsp/--fontSpace`を追加しました。
文字間隔が詰まって描画されてしまうfontがあり、見難いので追加しました。
